### PR TITLE
Docker Hub に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 ## Getting started
 
+### Running on Docker
+
+* Now available on Docker Hub!
+  * [windyakin/kosen-website-crawler](https://hub.docker.com/r/windyakin/kosen-website-crawler/)
+
+```
+docker-compose up -d
+```
+
+### Running on local machine
+
 required node version >= 7.10.0
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   crawler:
-    image: kosen_website_crawler
+    image: windyakin/kosen-website-crawler:latest
     build: .
     volumes:
       # NOTE: macOS の /etc/localtime はマウントしてもタイムゾーンを変更できない


### PR DESCRIPTION
## 概要
Docker Hub にイメージをビルドしてもらうようにした

https://hub.docker.com/r/windyakin/kosen-website-crawler/

## やっていること
* docker-compose で実行するときのイメージを Docker Hub から持ってくるようにする
* あわせてREADMEを更新する

## 確認方法
* `docker-compose pull` で Docker Hub からイメージをダウンロードできる
* `docker-compose build` で今まで通りビルドができる
* `docker-compose up` でスクリーンショットが撮影できる