### PR TITLE
Dockerイメージをダイエットする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4.0
+FROM node:8-slim
 
 # Install Font
 RUN mkdir /noto
@@ -8,6 +8,7 @@ RUN apt-get update \
     udev \
     unzip \
     ttf-freefont \
+    fontconfig \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 ADD https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip .
 RUN unzip NotoSansCJKjp-hinted.zip \
@@ -19,7 +20,8 @@ WORKDIR /
 RUN rm -rf /noto \
   && apt-get --force-yes remove -y --purge \
     unzip \
-    ttf-freefont
+    ttf-freefont \
+    fontconfig
 
 # Dependencies package
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
 FROM node:8-slim
 
 # Install Font
-RUN mkdir /noto
-WORKDIR /noto
-RUN apt-get update \
+RUN mkdir /noto \
+  && apt-get update \
   && apt-get install -y --no-install-recommends \
     udev \
     unzip \
-    ttf-freefont \
     fontconfig \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-ADD https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip .
-RUN unzip NotoSansCJKjp-hinted.zip \
+    ca-certificates \
+  && wget -q -O /noto/noto.zip https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
+  && unzip -d /noto/fonts /noto/noto.zip \
   && mkdir -p /usr/share/fonts/noto \
-  && cp *.otf /usr/share/fonts/noto \
+  && cp /noto/fonts/*.otf /usr/share/fonts/noto \
   && chmod 644 -R /usr/share/fonts/noto/ \
-  && fc-cache -fv
-WORKDIR /
-RUN rm -rf /noto \
+  && fc-cache -fv \
+  && rm -rf /noto \
   && apt-get --force-yes remove -y --purge \
     unzip \
-    ttf-freefont \
-    fontconfig
+    fontconfig \
+    ca-certificates \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Dependencies package
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:8-slim
 RUN mkdir /noto
 WORKDIR /noto
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     udev \
     unzip \
     ttf-freefont \
@@ -26,7 +26,7 @@ RUN rm -rf /noto \
 # Dependencies package
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
 RUN apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     gconf-service \
     libasound2 \
     libatk1.0-0 \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 ## Getting started
 
+### Running on Docker
+
+* Now available on Docker Hub!
+  * [windyakin/kosen-website-crawler](https://hub.docker.com/r/windyakin/kosen-website-crawler/)
+
+```
+docker-compose up -d
+```
+
+### Running on local machine
+
 required node version >= 7.10.0
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   crawler:
-    image: kosen_website_crawler
+    image: windyakin/kosen-website-crawler:latest
     build: .
     volumes:
       # NOTE: macOS の /etc/localtime はマウントしてもタイムゾーンを変更できない


### PR DESCRIPTION
## 概要
* #9 の続き
* イメージサイズがでかすぎなのであの手この手でダイエットしてみる

## やっていること
* ベースイメージを node:8-slim にする (約400MB 減)
  * ただ slim のイメージには fontconfig がはいってないので別途 apt-get でいれる
* apt-get install 時に `--no-install-recommends` をつける (約160MB 減)
* `ADD` とかつかわずに、1回の RUN でフォントインストールから残骸削除まで完結させる (約290MB 減)

## 確認方法
* `docker-compose build --pull` でビルドする
* `docker-compose up` で今まで通りスクリーンショットが撮影できる