### PR TITLE
松江高専と都城高専のURLを修正

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -121,7 +121,7 @@
   },
   {
     "name": "松江高専",
-    "url": "http://www.matsue-ct.ac.jp/"
+    "url": "http://www.matsue-ct.jp/m/index.php"
   },
   {
     "name": "津山高専",
@@ -193,7 +193,7 @@
   },
   {
     "name": "都城高専",
-    "url": "http://www.cc.miyakonojo-nct.ac.jp/"
+    "url": "http://www.miyakonojo-nct.ac.jp/"
   },
   {
     "name": "鹿児島高専",


### PR DESCRIPTION
URLが変更されていたことに伴い修正を行いました．
（松江高専は， `/m/index.php` に転送されるため，そのままベタ打ちしています）