### PR TITLE
Dockerで建てたダミーサーバーのスクショ撮影でCIをする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - DOCKER_COMPOSE_VERSION=1.17.1
 
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - sudo rm /usr/local/bin/docker-compose
   - curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > docker-compose
   - chmod +x docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_install:
   - curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-
 before_script:
   - docker-compose -f docker-compose.test.yml build --pull crawler
   - docker-compose -f docker-compose.test.yml pull otonokizaka uranohoshi
@@ -28,3 +27,7 @@ script:
 
 after_script:
   - docker-compose -f docker-compose.test.yml down
+
+notifications:
+  slack:
+    secure: O1tCfPsmyS1UKK5cAha7pXPXX4FFYoOvj26vaW+6xvqVNWqBTOp0t8OWBYZj0Q4r7zoL41r0L0txXIs12DSwpb+O/yGGwD96sSlAqMN8JHGsf0HzgASqMXNrF0KCcNHpaxdS8VcM2pJfWzAlmaz4At9GQqTrTJixa8Ybrel6H8S+n8ZV+p23BqWnYTALRxTaO4tn6KU2EVFbQgyGsO7GiQsyJLwpiMAo4DI7c1WAed6/NVnfhMuFeMKPrT0Q/JFjn23BOX6oRvUxFKow/HIxdMaHu49TJl+IUTFM0pwigtFRI1eKJK1ts+ahLeLJSSbY/p81o9a++5vLz6CLAAxofbUWWa5p1C78smvAyb4yZHT7UaAkV2QSpEZ0kmeEfV5eftUWgK173/NAGK+VVNO7UvejvXI20eUr/NJcWyRB2SapaNb6SOuRM6KCyBF6WmmQznPkCNMFcEgJQeSjTsLxkcYMoO1FUkEws8HqO7QTCB9Ta13skZdmpYhDfdXzp8ddSIZR7bnMI5oWebCBFeLwhreE02mIYdOEThOAxRmWTV3XM5oCRUiMbSws4C5YRGoSBzvsjjRn4nxalhOM9ogMWdLCNWio/BvbkxAmvAzP1e0N40AN3eUiGcf5ORbectPJDqH0gQMs6aoT3wO1FDjv+avlzclvgRjjeE2TL65N4OM=

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - sudo mv docker-compose /usr/local/bin
 
 before_script:
+  - docker-compose -f docker-compose.test.yml build --pull crawler
+  - docker-compose -f docker-compose.test.yml pull otonokizaka uranohoshi
   - docker-compose -f docker-compose.test.yml up -d otonokizaka uranohoshi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - docker-compose -f docker-compose.test.yml up -d otonokizaka uranohoshi
 
 script:
-  - docker-compose -f docker-compose.test.yml runcrawler
+  - docker-compose -f docker-compose.test.yml run crawler
 
 after_script:
   - docker-compose -f docker-compose.test.yml down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language: node
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.17.1
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+before_script:
+  - docker-compose -f docker-compose.test.yml up -d otonokizaka uranohoshi
+
+script:
+  - docker-compose -f docker-compose.test.yml runcrawler
+
+after_script:
+  - docker-compose -f docker-compose.test.yml down

--- a/app.js
+++ b/app.js
@@ -34,6 +34,9 @@ logger.level = 'debug';
       await page.screenshot({ path: filePath, fullPage: true });
     } catch (e) {
       logger.error(e);
+      if (process.env.NODE_ENV === 'test') {
+        process.exit(1);
+      }
       return;
     }
     logger.info(`Saved! ${filePath}`);

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  crawler:
+    image: windyakin/kosen-website-crawler:latest
+    build: .
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./fake_content/websites.json:/usr/src/app/websites.json:ro
+      - ./screenshots:/usr/src/app/screenshots
+    environment:
+      - TZ=Asia/Tokyo
+      - NODE_ENV=test
+    shm_size: 256m
+  otonokizaka:
+    image: nginx:latest
+    volumes:
+      - ./fake_content/otonokizaka:/usr/share/nginx/html:ro
+  uranohoshi:
+    image: nginx:latest
+    volumes:
+      - ./fake_content/uranohoshi:/usr/share/nginx/html:ro

--- a/fake_content/otonokizaka/index.html
+++ b/fake_content/otonokizaka/index.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Otonokizaka</title>
+  <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, 'Arial', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', 'メイリオ', Meiryo, sans-serif;
+      }
+    </style>
+  </head>
+<body>
+  <h1>Otonokizaka</h1>
+
+  <h2>日本語</h2>
+  <p>秋葉原と神田と神保町という3つの街のはざまにある伝統校、音ノ木坂学院は統廃合の危機に瀕していた。</p>
+  <p>学校の危機に、2年生の高坂穂乃果を中心とした9人の女子生徒が立ち上がる。</p>
+  <p>私たちの大好きな学校を守るために、私たちができること……。それは、アイドルになること！</p>
+  <p>アイドルになって学校を世に広く宣伝し、入学者を増やそう！</p>
+  <p>ここから、彼女たちの「みんなで叶える物語」が始まった！</p>
+
+  <h2>English</h2>
+  <p>The story is set in Tokyo, where an old school right in between the neighborhoods of Akihabara, Kanda and Jinbocho is in danger of consolidation and closure.</p>
+  <p>Nine girls, centering Honoka Kosaka, have stepped up to defy the imminent danger facing their school.</p>
+  <p>"If we want to protect our beloved school, we need to do what we can? we need to become idols!" Hoping against hope there's something they can do about this, the girls strive to become famous, spread the word about their school, attract more students, and save the day.</p>
+  <p>Now their "School Idol Project" begins to make their dreams come true! "Make our dreams come true!"</p>
+  <p>Who are the School Idols? School Idols are idol groups formed in schools by students. Although they're just students, these top-class school idol groups have enjoyed major popularity among teenage fans. They get major exposure through media like magazines, and the schools that feature these popular school idols gain a lot of attention from all over the country.</p>
+</body>
+</html>

--- a/fake_content/uranohoshi/index.html
+++ b/fake_content/uranohoshi/index.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Uranohoshi</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, 'Arial', 'ヒラギノ角ゴ ProN W3', 'Hiragino Kaku Gothic ProN', 'メイリオ', Meiryo, sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <h1>Uranohoshi</h1>
+
+  <h2>日本語</h2>
+  <p>静岡県沼津市の海辺の町、内浦にある私立浦の星女学院。</p>
+  <p>駿河湾のかたすみにある小さな高校で2年生の高海千歌を中心とした9人の少女たちが、大きな夢を抱いて立ち上がる。</p>
+  <p>それは、キラキラと輝く“スクールアイドル”になること！</p>
+  <p>諦めなければきっと夢は叶う――。いまはただ輝きを目指して、がむしゃらに駆け抜けていこう！ここから彼女たちの「みんなで叶える物語」が始まった！</p>
+
+  <h2>English</h2>
+  <p>Uranohoshi Girls' High School, a private school in the seaside neighborhood of Uchiura at Numazu city, Shizuoka prefecture.</p>
+  <p>A small high school in a corner of Suruga Bay, it is home to nine teens, led by second-year student Chika Takami, driven by one seriously big dream:</p>
+  <p>To become the next generation of bright, sparkling "school idols"!</p>
+  <p>As long as we don’t give up, any dream can come true... All we have to do now is keep pushing hard for glory!</p>
+  <p>Now their "School Idol Project" begins to make their dreams come true!</p>
+</body>
+</html>

--- a/fake_content/websites.json
+++ b/fake_content/websites.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "音ノ木坂学院",
+    "url": "http://otonokizaka/"
+  },
+  {
+    "name": "浦の星女学院",
+    "url": "http://uranohoshi/"
+  }
+]


### PR DESCRIPTION
## 概要
CIっぽいなにかを実装する

## やってること
* Docker でただのHTMLを返すダミーサーバーコンテナを2つほど立てる
* ダミーサーバーのコンテンツを撮影するように websites.json を volume で override する
* 撮影する
* TravisCI に登録した

## やってないこと
* 撮影した結果がみえない
* まあプログラムのエラーぐらいは気付けるじゃん？

## 確認方法
* このPRでCIが動いてるっぽいことを確認する
* travis-ci.yml に書いてあるようなことと同じことをしてスクショが撮影できることを確認する