### PR TITLE
DockerのあれこれのコマンドをMakefileにする

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,8 @@ indent_size = 2
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+tab_width = 4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+COMPOSE_FILES := docker-compose.yml
+COMPOSE_FILES_ON_COMMAND_LINE := $(addprefix -f ,$(COMPOSE_FILES))
+CRAWLER_CONTAINER_ID := $(shell docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) ps -q crawler)
+
+all: run copy down
+
+ps:
+	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) ps
+
+build:
+	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) build
+
+run:
+	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) up
+
+copy:
+	docker cp $(CRAWLER_CONTAINER_ID):/usr/src/app/screenshots .
+
+down:
+	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) down
+
+.PHONY: all ps build run copy down

--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@
 
 * [windyakin/kosen-website-crawler](https://hub.docker.com/r/windyakin/kosen-website-crawler/) 
 
+#### Run
+
 ```
-docker-compose up -d
+make
+```
+
+#### Build Docker image by yourself
+
+```
+make build
 ```
 
 ### Running on local machine

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -xe
-
-docker-compose -f docker-compose.yml build
-docker-compose -f docker-compose.yml up
-docker cp $(docker-compose ps -q crawler):/usr/src/app/screenshots .
-docker-compose -f docker-compose.yml down


### PR DESCRIPTION
## 概要

* いちいち docker-compose するのが面倒なので Makefile に集約する
* run.sh を廃止
* README を更新

## 確認方法

* `make build` でイメージのビルドが動く事を確認する
* `make` で起動・取得・コピー・シャットダウン まで行われる