### PR TITLE
/etc/localtime をマウントしない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 screenshots/*
 !screenshots/.keep
 
+docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ ps:
 build:
 	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) build
 
+pull:
+	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) pull
+
 run:
 	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) up
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,8 +1,0 @@
-version: '3'
-
-services:
-  crawler:
-    volumes:
-      - ./screenshots:/usr/src/app/screenshots
-      - ./app.js:/usr/src/app/app.js
-      - ./websites.json:/usr/src/app/websites.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
   crawler:
     image: windyakin/kosen-website-crawler:latest
     build: .
-    volumes:
-      # NOTE: macOS の /etc/localtime はマウントしてもタイムゾーンを変更できない
-      - /etc/localtime:/etc/localtime:ro
     environment:
       - TZ=Asia/Tokyo
     shm_size: 256m


### PR DESCRIPTION
## 概要
Docker for Mac がアップデートしたら /etc/localtime をマウントできなくなったので

## やっていること
* /etc/localtime のマウントをやめる
* docker-compose.override.yml の git トラッキングをやめる
  * 自由に書いてﾈ

## 確認方法
今まで通り動くかどうか