### PR TITLE
Pageのライフサイクルの変更とPromiseのリファクタリング

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,10 +20,7 @@ logger.level = 'debug';
 
   const browser = await Puppeteer.launch({ args: puppeteerParam });
 
-  await new Promise(resolve => resolve(
-    websites,
-    Array.from(Array(websites.length).keys()),
-  )).each(async (website, index) => {
+  await Promise.each(websites, async (website, index) => {
     const page = await browser.newPage();
     await page.setViewport({ width: 1280, height: 720 });
     const fileIndex = (index + 1).toString().padStart(2, '0');

--- a/app.js
+++ b/app.js
@@ -19,13 +19,13 @@ logger.level = 'debug';
   const puppeteerParam = (os.platform() === 'linux' ? ['--no-sandbox', '--disable-setuid-sandbox'] : []);
 
   const browser = await Puppeteer.launch({ args: puppeteerParam });
-  const page = await browser.newPage();
-  page.setViewport({ width: 1280, height: 720 });
 
   await new Promise(resolve => resolve(
     websites,
     Array.from(Array(websites.length).keys()),
   )).each(async (website, index) => {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1280, height: 720 });
     const fileIndex = (index + 1).toString().padStart(2, '0');
     const filePath = `${folderName}/${fileIndex}_${website.name}.png`;
     logger.info(`Get ${website.name} (${website.url}) ...`);
@@ -39,6 +39,7 @@ logger.level = 'debug';
       }
       return;
     }
+    await page.close();
     logger.info(`Saved! ${filePath}`);
   });
 


### PR DESCRIPTION
## 概要

* 最初に作った page を使いまわしていたのを、ページアクセスごとに捨てて作り直すようにする
* [Promise.prototype.each](http://bluebirdjs.com/docs/api/each.html) から [Promise.each](http://bluebirdjs.com/docs/api/promise.each.html) に変更する
  * 何をしているかと、どこから index を取得したかとかがわかりやすくなる

## 確認方法

* 今まで通り動く
* L.21 の Puppeteer.launch の options に `headless: false` を追加して起動した際に、タブが開いたり閉じたりしている