### PR TITLE
makeコマンドから動かしたときにコンテナからのコピーが上手く動かない問題の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 COMPOSE_FILES := docker-compose.yml
 COMPOSE_FILES_ON_COMMAND_LINE := $(addprefix -f ,$(COMPOSE_FILES))
-CRAWLER_CONTAINER_ID := $(shell docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) ps -q crawler)
 
 all: run copy down
 
@@ -17,7 +16,7 @@ run:
 	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) up
 
 copy:
-	docker cp $(CRAWLER_CONTAINER_ID):/usr/src/app/screenshots .
+	docker cp $(shell docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) ps -q crawler):/usr/src/app/screenshots .
 
 down:
 	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) down

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ copy:
 down:
 	docker-compose $(COMPOSE_FILES_ON_COMMAND_LINE) down
 
-.PHONY: all ps build run copy down
+.PHONY: all ps build pull run copy down


### PR DESCRIPTION
## 概要

* Makefile の変数の扱いがよくわかってなかった
* 多分makeを最初に立ち上げた時のコンテナIDを使おうとするため空っぽになる

## やったこと

* 必要なときにコンテナIDをもらう
* .PHONYに追加し忘れてた