### PR TITLE
テスト用のコンテンツにviewportを設定する

### DIFF
--- a/test/integrations/fake_content/otonokizaka/index.html
+++ b/test/integrations/fake_content/otonokizaka/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Otonokizaka</title>
   <style>
       body {

--- a/test/integrations/fake_content/uranohoshi/index.html
+++ b/test/integrations/fake_content/uranohoshi/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Uranohoshi</title>
   <style>
     body {


### PR DESCRIPTION
## 概要
* テスト用コンテンツに viewport を設定する

## 確認方法

```sh
cd test/integration
docker-compose -f docker-compose.yml run -v $(pwd)/screenshots:/usr/src/app/screenshots crawler
```

このブランチの変更差分が入っている状態と入っていない状態で、上記のコマンドを実行し test/integration/screenshots 以下に保存されるスマートフォン表示が異なっていることを確認する。

## 例

### 変更前

![変更前](https://user-images.githubusercontent.com/3339003/49410642-fa421000-f7a8-11e8-80bc-54e512e1c701.png)

### 変更後

![変更後](https://user-images.githubusercontent.com/3339003/49410662-0b8b1c80-f7a9-11e8-9cf2-b010a65536fb.png)

