### PR TITLE
HTTPS化した高専の対応

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -5,7 +5,7 @@
   },
   {
     "name": "苫小牧高専",
-    "url": "http://www.tomakomai-ct.ac.jp/"
+    "url": "https://www.tomakomai-ct.ac.jp/"
   },
   {
     "name": "釧路高専",
@@ -133,7 +133,7 @@
   },
   {
     "name": "呉高専",
-    "url": "http://www.kure-nct.ac.jp/"
+    "url": "https://www.kure-nct.ac.jp/"
   },
   {
     "name": "徳山高専",


### PR DESCRIPTION
なんでHSTSやHTTP 301でHTTPS転送しないんだ…

|高専名|旧URL|新URL|
|:---:|:---:|:---:|
|苫小牧高専|http://www.tomakomai-ct.ac.jp/|https://www.tomakomai-ct.ac.jp/|
|呉高専|http://www.kure-nct.ac.jp/|https://www.kure-nct.ac.jp/|