### PR TITLE
GitHub Actions をつかった CI/CD を強化します

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,55 @@
+name: check
+
+on:
+  schedule:
+    - cron: '0 10 15 * *'
+
+jobs:
+  websites:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check websites.json URLs
+        run: |
+         cat "${GITHUB_WORKSPACE}/websites.json" | \
+         jq --raw-output ".[].url" | \
+         xargs -I _URL_ curl -s -L -o /dev/null --write-out "_URL_ %{url_effective} %{http_code}\n" _URL_ | \
+         awk 'BEGIN { OFS="|" } ($1 != $2 || $3 != 200) { print $1,$2,$3 }' > "${GITHUB_WORKSPACE}/failed_list.md"
+
+      - name: Check failed list file
+        id: check_failed_list_file
+        run: |
+          echo "::set-output name=is_empty::$(test -s failed_list.md; echo $?)"
+
+      - name: Craete issue format
+        if: ${{ steps.check_failed_list_file.output.is_empty == 0 }}
+        run: |
+          cat << EOF > "${GITHUB_WORKSPACE}/issue.md"
+          websites.json のURLから移転、またはHTTPステータスコードのおかしいウェブサイトを発見しました。
+
+          現行URL|移転先URL|Status
+          ---|---|---
+          $(cat ${GITHUB_WORKSPACE}/failed_list.md)
+
+          ---
+          この Issue は GitHub Actions で作成されました
+          EOF
+
+      - name: Get date
+        if: ${{ steps.check_failed_list_file.outputs.is_empty == 0 }}
+        id: date
+        run: echo "::set-output name=text::$(date +'%Y年%m月')"
+
+      - name: Create issue
+        if: ${{ steps.check_failed_list_file.outputs.is_empty == 0 }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const fs = require('fs').promises;
+            await github.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '${{ steps.date.outputs.text }} websites.json チェック',
+              body: (await (fs.readFile(`${ process.env.GITHUB_WORKSPACE }/issue.md`, 'utf-8')))
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,37 @@
-name: Build the Docker image test
+name: ci
 
 on:
   pull_request:
-  push:
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 
-      - name: Build the Docker image
-        run: docker build --pull --no-cache . -f Dockerfile
+      - uses: docker/setup-qemu-action@v1
+
+      - uses: docker/setup-buildx-action@v1
+
+      - uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          tags: windyakin/kosen-website-crawler:latest
+          push: false
+
+  eslint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+
+      - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,3 @@ jobs:
           platforms: linux/amd64
           tags: windyakin/kosen-website-crawler:latest
           push: false
-
-  eslint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - run: npm install
-
-      - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,20 @@ jobs:
           platforms: linux/amd64
           tags: windyakin/kosen-website-crawler:latest
           push: false
+
+  eslint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm install
+
+      - run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,16 +9,30 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
 
-      - name: Build the Docker Image
-        run: docker build --pull --no-cache . -f Dockerfile --tag windyakin/kosen-website-crawler:latest
+      - uses: actions/checkout@v2
+
+      - uses: docker/setup-qemu-action@v1
+
+      - uses: docker/setup-buildx-action@v1
 
       - name: Login to the Docker Hub
-        env:
-          DOCKER_USERNAME: windyakin
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Publish to Docker Hub
-        run: docker push windyakin/kosen-website-crawler:latest
+      - name: Login to the GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          tags: |
+            windyakin/kosen-website-crawler:latest
+            ghcr.io/windyakin/kosen-website-crawler:latest
+          push: true


### PR DESCRIPTION
## 概要

メインは websites.json のチェック CI の追加

ついでに既存の GitHub Actions がよくできそうだったのでやります（一緒のPRでやるな）

## やったこと

- Docker 公式の Actions を使ってビルドテストやイメージの公開を行うようにします
- ESLint の CI を追加します
- websites.json のURLをチェックしてくれるCIを追加します