### PR TITLE
websites.json を修正

### DIFF
--- a/websites.json
+++ b/websites.json
@@ -13,7 +13,7 @@
   },
   {
     "name": "旭川高専",
-    "url": "http://www.asahikawa-nct.ac.jp/"
+    "url": "https://www.asahikawa-nct.ac.jp/"
   },
   {
     "name": "八戸高専",
@@ -37,7 +37,7 @@
   },
   {
     "name": "福島高専",
-    "url": "http://www.fukushima-nct.ac.jp/"
+    "url": "https://www.fukushima-nct.ac.jp/"
   },
   {
     "name": "茨城高専",
@@ -49,7 +49,7 @@
   },
   {
     "name": "群馬高専",
-    "url": "http://www.gunma-ct.ac.jp/"
+    "url": "https://www.gunma-ct.ac.jp/"
   },
   {
     "name": "木更津高専",
@@ -61,7 +61,7 @@
   },
   {
     "name": "長岡高専",
-    "url": "http://www.nagaoka-ct.ac.jp/"
+    "url": "https://www.nagaoka-ct.ac.jp/"
   },
   {
     "name": "長野高専",
@@ -81,7 +81,7 @@
   },
   {
     "name": "岐阜高専",
-    "url": "http://www.gifu-nct.ac.jp/"
+    "url": "https://www.gifu-nct.ac.jp/"
   },
   {
     "name": "沼津高専",
@@ -113,7 +113,7 @@
   },
   {
     "name": "和歌山高専",
-    "url": "http://www.wakayama-nct.ac.jp/"
+    "url": "https://www.wakayama-nct.ac.jp/"
   },
   {
     "name": "米子高専",
@@ -121,7 +121,7 @@
   },
   {
     "name": "松江高専",
-    "url": "http://www.matsue-ct.jp/m/index.php"
+    "url": "https://www.matsue-ct.jp/m/index.php"
   },
   {
     "name": "津山高専",
@@ -137,11 +137,11 @@
   },
   {
     "name": "徳山高専",
-    "url": "http://www.tokuyama.ac.jp/"
+    "url": "https://www.tokuyama.ac.jp/"
   },
   {
     "name": "宇部高専",
-    "url": "http://www.ube-k.ac.jp/"
+    "url": "https://www.ube-k.ac.jp/"
   },
   {
     "name": "大島商船高専",
@@ -189,7 +189,7 @@
   },
   {
     "name": "大分高専",
-    "url": "http://www.oita-ct.ac.jp/"
+    "url": "https://www.oita-ct.ac.jp/"
   },
   {
     "name": "都城高専",
@@ -221,7 +221,7 @@
   },
   {
     "name": "府大高専",
-    "url": "http://www2.ct.osakafu-u.ac.jp/"
+    "url": "https://www2.ct.osakafu-u.ac.jp/"
   },
   {
     "name": "神戸高専",

--- a/websites.json
+++ b/websites.json
@@ -137,7 +137,7 @@
   },
   {
     "name": "徳山高専",
-    "url": "http://www.tokuyama.ac.jp"
+    "url": "http://www.tokuyama.ac.jp/"
   },
   {
     "name": "宇部高専",


### PR DESCRIPTION
## 概要

* 徳山高専のURLに末尾のスラッシュが抜けていたので追加
  * ref: https://github.com/windyakin/kosen-website-crawler/issues/121
* HTTPS に対応しているウェブサイトには HTTPS で接続するようにします